### PR TITLE
Don't use bevy dependency directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ clippy.wildcard_dependencies = "warn"
 [dependencies]
 tokio = { version = "1.44.2", default-features = false, features = ["sync"] }
 
-bevy_ecs = { version = "0.16.0", default-features = false }
-bevy_tasks = { version = "0.16.0", default-features = false, features = ["multi_threaded"] }
+bevy_ecs = { version = "0.16.0", default-features = false, features = ["multi_threaded", "async_executor"] }
+bevy_tasks = { version = "0.16.0", default-features = false, features = ["async_executor"] }
 bevy_utils = { version = "0.16.0", default-features = false }
 
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/loopystudios/bevy_async_task"
 authors = ["Spencer C. Imbleau"]
 keywords = ["gamedev", "async"]
 categories = ["game-development", "asynchronous"]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 
 [lints]
@@ -74,14 +74,21 @@ clippy.wildcard_dependencies = "warn"
 
 [dependencies]
 tokio = { version = "1.44.2", default-features = false, features = ["sync"] }
-bevy = { version = "0.16.0", default-features = false, features = [
-  "multi_threaded",
-  "bevy_log",
-] }
+
+bevy_ecs = { version = "0.16.0", default-features = false }
+bevy_tasks = { version = "0.16.0", default-features = false, features = ["multi_threaded"] }
+bevy_utils = { version = "0.16.0", default-features = false }
+
 thiserror = "2.0.12"
 futures = "0.3.31"
 futures-timer = "3.0.3"
 web-time = "1.1.0"
+
+[dev-dependencies]
+bevy = { version = "0.16.0", default-features = false, features = [
+  "multi_threaded",
+  "bevy_log",
+] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-compat = "0.2.4"

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,7 +1,7 @@
 use crate::{AsyncReceiver, Duration, error::TimeoutError, sleep, util::timeout};
 #[cfg(not(target_arch = "wasm32"))]
 use async_compat::CompatExt;
-use bevy::tasks::{ConditionalSend, ConditionalSendFuture};
+use bevy_tasks::{ConditionalSend, ConditionalSendFuture};
 use futures::task::AtomicWaker;
 use std::{
     fmt::Debug,

--- a/src/task_pool.rs
+++ b/src/task_pool.rs
@@ -1,14 +1,11 @@
 use crate::{AsyncReceiver, AsyncTask, TimedAsyncTask, TimeoutError};
-use bevy::{
-    ecs::{
-        component::Tick,
-        system::{ExclusiveSystemParam, ReadOnlySystemParam, SystemMeta, SystemParam},
-        world::unsafe_world_cell::UnsafeWorldCell,
-    },
-    prelude::*,
-    tasks::{AsyncComputeTaskPool, ConditionalSend},
-    utils::synccell::SyncCell,
+use bevy_ecs::{
+    component::Tick,
+    system::{ExclusiveSystemParam, ReadOnlySystemParam, SystemMeta, SystemParam},
+    world::{World, unsafe_world_cell::UnsafeWorldCell},
 };
+use bevy_tasks::{AsyncComputeTaskPool, ConditionalSend};
+use bevy_utils::synccell::SyncCell;
 use std::task::Poll;
 
 /// A Bevy [`SystemParam`] to execute many similar [`AsyncTask`]s in the

--- a/src/task_runner.rs
+++ b/src/task_runner.rs
@@ -1,14 +1,11 @@
 use crate::{AsyncReceiver, AsyncTask, TimedAsyncTask, TimeoutError};
-use bevy::{
-    ecs::{
-        component::Tick,
-        system::{ExclusiveSystemParam, ReadOnlySystemParam, SystemMeta, SystemParam},
-        world::unsafe_world_cell::UnsafeWorldCell,
-    },
-    prelude::*,
-    tasks::{AsyncComputeTaskPool, ConditionalSend},
-    utils::synccell::SyncCell,
+use bevy_ecs::{
+    component::Tick,
+    system::{ExclusiveSystemParam, ReadOnlySystemParam, SystemMeta, SystemParam},
+    world::{World, unsafe_world_cell::UnsafeWorldCell},
 };
+use bevy_tasks::{AsyncComputeTaskPool, ConditionalSend};
+use bevy_utils::synccell::SyncCell;
 use std::{
     ops::{Deref, DerefMut},
     sync::atomic::Ordering,


### PR DESCRIPTION
This PR replaces the direct bevy dependency with bevy_ecs, bevy_tasks and bevy_utils, to reduce the amount of dependencies when using bevy_async_task.

Reduces dependencies from 294 to 189.