### PR TITLE
refactor: remove async-compat, as it is no longer needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ bevy = { version = "0.17.2", default-features = false, features = [
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures-timer = "3.0.3"
-async-compat = "0.2.5"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures-timer = { version = "3.0.3", features = ["wasm-bindgen"] }

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 [![Discord](https://img.shields.io/discord/913957940560531456.svg?label=Loopy&logo=discord&logoColor=ffffff&color=ffffff&labelColor=000000)](https://discord.gg/zrjnQzdjCB)
 ![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)
-[![Build status](https://github.com/loopystudios/bevy_async_task/workflows/CI/badge.svg)](https://github.com/loopystudios/bevy_async_task/actions)
+[![Following released Bevy versions](https://img.shields.io/badge/bevy%20tracking-released%20version-lightblue)](https://bevyengine.org/learn/quick-start/plugin-development/#main-branch-tracking)\
 [![Dependency status](https://deps.rs/repo/github/loopystudios/bevy_async_task/status.svg)](https://deps.rs/repo/github/loopystudios/bevy_async_task)
 [![crates.io](https://img.shields.io/crates/v/bevy_async_task.svg)](https://crates.io/crates/bevy_async_task)
 [![docs.rs](https://img.shields.io/docsrs/bevy_async_task)](https://docs.rs/bevy_async_task)
+[![Build status](https://github.com/loopystudios/bevy_async_task/workflows/CI/badge.svg)](https://github.com/loopystudios/bevy_async_task/actions)
 
 A minimum crate for ergonomic abstractions to async programming in Bevy. There is full API support for **wasm** and **native**. Android and iOS are untested (Help needed).
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -7,8 +7,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::task::Poll;
 
-#[cfg(not(target_arch = "wasm32"))]
-use async_compat::CompatExt;
 use bevy_tasks::ConditionalSend;
 use bevy_tasks::ConditionalSendFuture;
 use futures::task::AtomicWaker;
@@ -93,10 +91,7 @@ where
             let waker = waker.clone();
             let received = received.clone();
             async move {
-                #[cfg(target_arch = "wasm32")]
                 let result = self.fut.await;
-                #[cfg(not(target_arch = "wasm32"))]
-                let result = self.fut.compat().await;
 
                 if let Ok(()) = tx.send(result) {
                     // Wait for the receiver to get the result before dropping.
@@ -193,10 +188,7 @@ where
             let waker = waker.clone();
             let received = received.clone();
             async move {
-                #[cfg(target_arch = "wasm32")]
                 let result = timeout(self.timeout, self.fut).await;
-                #[cfg(not(target_arch = "wasm32"))]
-                let result = timeout(self.timeout, self.fut.compat()).await;
 
                 if let Ok(()) = tx.send(result) {
                     // Wait for the receiver to get the result before dropping.


### PR DESCRIPTION
The Bevy MSRV is above 1.79, effectively removing the friction between old async executors (futures and tokio). Async compat is no longer necessary.