### PR TITLE
update to bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/loopystudios/bevy_async_task"
 authors = ["Spencer C. Imbleau"]
 keywords = ["gamedev", "async"]
 categories = ["game-development", "asynchronous"]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 
 [lints]
@@ -61,21 +61,21 @@ clippy.wildcard_dependencies = "warn"
 [lib]
 
 [dependencies]
-bevy_ecs = { version = "0.17.3", default-features = false, features = [
+bevy_ecs = { version = "0.18", default-features = false, features = [
   "multi_threaded",
   "async_executor",
 ] }
-bevy_tasks = { version = "0.17.3", default-features = false, features = [
+bevy_tasks = { version = "0.18", default-features = false, features = [
   "async_executor",
 ] }
-bevy_platform = { version = "0.17.3", default-features = false }
+bevy_platform = { version = "0.18", default-features = false }
 
 thiserror = "2.0.17"
 futures = "0.3.31"
 web-time = "1.1.0"
 
 [dev-dependencies]
-bevy = { version = "0.17.3", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
   "multi_threaded",
   "bevy_log",
 ] }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Bevy Async Task provides Bevy system parameters to run asynchronous tasks in the
 
 |bevy|bevy_async_task|
 |---|---|
-|0.17|0.9-0.11,main|
+|0.18|0.12,main|
+|0.17|0.9-0.11|
 |0.16|0.6-0.8|
 |0.15|0.3-0.5|
 |0.14|0.2|

--- a/src/task_pool.rs
+++ b/src/task_pool.rs
@@ -1,6 +1,6 @@
 use std::task::Poll;
 
-use bevy_ecs::component::Tick;
+use bevy_ecs::change_detection::Tick;
 use bevy_ecs::system::ExclusiveSystemParam;
 use bevy_ecs::system::ReadOnlySystemParam;
 use bevy_ecs::system::SystemMeta;

--- a/src/task_runner.rs
+++ b/src/task_runner.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 use std::task::Poll;
 
-use bevy_ecs::component::Tick;
+use bevy_ecs::change_detection::Tick;
 use bevy_ecs::system::ExclusiveSystemParam;
 use bevy_ecs::system::ReadOnlySystemParam;
 use bevy_ecs::system::SystemMeta;

--- a/src/task_stream.rs
+++ b/src/task_stream.rs
@@ -1,6 +1,6 @@
 use std::task::Poll;
 
-use bevy_ecs::component::Tick;
+use bevy_ecs::change_detection::Tick;
 use bevy_ecs::system::ExclusiveSystemParam;
 use bevy_ecs::system::ReadOnlySystemParam;
 use bevy_ecs::system::SystemMeta;


### PR DESCRIPTION
only required minimal import change: https://bevy.org/learn/migration-guides/0-17-to-0-18/#tick-related-refactors